### PR TITLE
Fix of some minor bugs when using the driver manifest and update helm chart versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,15 +128,15 @@ jobs:
       - name: Create manifest
         run: |
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,' | sed -e 's/^v//')
-          echo "---" >> manifest.yaml
+          printf "---\n" >> manifest.yaml
           cat deploy/k8s/rbac.yaml >> manifest.yaml
-          echo "---" >> manifest.yaml
+          printf "---\n" >> manifest.yaml
           cat deploy/k8s/csidriver.yaml >> manifest.yaml
-          echo "---" >> manifest.yaml
+          printf "---\n" >> manifest.yaml
           sed -E "s|(image: +${REGISTRY_NAME}/cloudstack-csi-driver)(:[^ ]+)?|\\1:${VERSION}|" deploy/k8s/controller-deployment.yaml >> manifest.yaml
-          echo "---" >> manifest.yaml
+          printf "---\n" >> manifest.yaml
           sed -E "s|(image: +${REGISTRY_NAME}/cloudstack-csi-driver)(:[^ ]+)?|\\1:${VERSION}|" deploy/k8s/node-daemonset.yaml >> manifest.yaml
-          echo "---" >> manifest.yaml
+          printf "---\n" >> manifest.yaml
           cat deploy/k8s/volume-snapshot-class.yaml >> manifest.yaml
 
       - name: Create Release

--- a/charts/cloudstack-csi/Chart.yaml
+++ b/charts/cloudstack-csi/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: cloudstack-csi
 description: A Helm chart for CloudStack CSI driver
 type: application
-version: 3.0.0
-appVersion: 0.6.1
+version: 3.0.1
+appVersion: 3.0.0
 sources:
   - https://github.com/cloudstack/cloudstack-csi-driver
 keywords:

--- a/charts/cloudstack-csi/values.yaml
+++ b/charts/cloudstack-csi/values.yaml
@@ -280,7 +280,7 @@ node:
     annotations: {}
     automountServiceAccountToken: true
   # Metadata source to try to find instance ID.
-  # Possible values 'cloud-init' & 'ignition'
+  # Possible values 'cloud-init' & 'ignition' or ''
   metadataSource: ignition
   # The maximum number of volumes that can be attached to a node
   volumeAttachLimit:


### PR DESCRIPTION
Fix of some minor bugs when using the driver manifest or helm chart. This should also create a new helm release 3.0.1 with the current app version 3.0.0.

*Description of changes:*

- The `manifest.yml` was missing a line break between two resources
- Update of the app version in the helm chart to 3.0.0
- Add a third empty option to the helm value `node.metadataSource` description as a feasible option (csi will take the name of the kubernetes node)

*Testing performed:*

I have set up a cluster in a private Cloudstack instance with Talos. This cluster works with the current version (3.0.0) of the csi plugin. I made some config overrides in the helm chart values by adjusting them manually. These overrides were done with terraform and can be reproduced:

```terraform
resource "helm_release" "cloudstack_csi_driver" {
  name      = "cloudstack-csi"
  chart     = "https://github.com/cloudstack/cloudstack-csi-driver/releases/download/cloudstack-csi-2.0.3/cloudstack-csi-2.0.3.tgz"
  version   = "2.0.3"
  atomic    = true
  namespace = "kube-system"
  set = [
    {
      name  = "cloudConfigData.global.api-url"
      value = var.cloudstack_api_url
    },
    {
      name  = "secret.create"
      value = true
    },
    {
      name  = "secret.enabled"
      value = true
    },
    {
      name  = "controller.image.tag"
      value = "3.0.0"
    },
    {
      name  = "syncer.image.tag"
      value = "3.0.0"
    },
    {
      name  = "node.image.tag"
      value = "3.0.0"
    },
    {
      name = "node.metadataSource"
      value = ""
    }
  ]
  set_sensitive = [
    {
      name  = "cloudConfigData.global.api-key"
      value = var.cloudstack_api_key
    },
    {
      name  = "cloudConfigData.global.secret-key"
      value = var.cloudstack_secret_key
    }
  ]
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
