### PR TITLE
Fix getVMByName to include projectID parameter

### DIFF
--- a/pkg/cloud/vms.go
+++ b/pkg/cloud/vms.go
@@ -59,8 +59,12 @@ func (c *client) getVMByName(ctx context.Context, name string) (*VM, error) {
 	logger := klog.FromContext(ctx)
 	p := c.VirtualMachine.NewListVirtualMachinesParams()
 	p.SetName(name)
+	if c.projectID != "" {
+		p.SetProjectid(c.projectID)
+	}
 	logger.V(2).Info("CloudStack API call", "command", "ListVirtualMachines", "params", map[string]string{
-		"name": name,
+		"name":      name,
+		"projectID": c.projectID,
 	})
 	l, err := c.VirtualMachine.ListVirtualMachines(p)
 	if err != nil {


### PR DESCRIPTION
  When VMs are deployed in a CloudStack project, the getVMByName function
  fails to find them because it doesn't include the projectID parameter
  in the ListVirtualMachines API call.

  This fix adds the projectID parameter to getVMByName, making it consistent
  with GetVMByID which already correctly handles project-scoped VMs.

*Issue #, if available:*

*Description of changes:*

*Testing performed:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
