### PR TITLE
Fix bug in cloud client missing the project id and refactor the package

### DIFF
--- a/charts/cloudstack-csi/Chart.yaml
+++ b/charts/cloudstack-csi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudstack-csi
 description: A Helm chart for CloudStack CSI driver
 type: application
-version: 3.0.1
+version: 3.0.2
 appVersion: 3.0.0
 sources:
   - https://github.com/cloudstack/cloudstack-csi-driver

--- a/charts/cloudstack-csi/templates/syncer-job.yaml
+++ b/charts/cloudstack-csi/templates/syncer-job.yaml
@@ -14,6 +14,7 @@ metadata:
   {{- end }}
 spec:
   backoffLimit: {{ .Values.syncer.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.syncer.ttlSecondsAfterFinished }}
   template:
     spec:
       securityContext: {{- toYaml .Values.syncer.podSecurityContext | nindent 8 }}

--- a/charts/cloudstack-csi/values.yaml
+++ b/charts/cloudstack-csi/values.yaml
@@ -350,6 +350,7 @@ syncer:
 
   # Job configurations
   backoffLimit: 4
+  ttlSecondsAfterFinished: 60
   restartPolicy: Never
 
   # securityContext on the syncer job

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -108,8 +108,8 @@ type client struct {
 func New(config *Config) Interface {
 	csClient := cloudstack.NewAsyncClient(config.APIURL, config.APIKey, config.SecretKey, config.VerifySSL)
 
-	// Set the project id to every request.
-	// This is possible because we just could work in one project with the previous implementation.
+	// Set the project id to every request that support options.
+	// This is possible because we also could work in one project only with the previous implementation.
 	if config.ProjectID != "" {
 		csClient.DefaultOptions(cloudstack.WithProject(config.ProjectID))
 		klog.Background().V(2).Info("Set projectID to cloud connector", "projectID", config.ProjectID)

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -71,7 +71,7 @@ type Volume struct {
 	DeviceID         string
 }
 
-// Volume represents a CloudStack snapshot.
+// Snapshot represents a CloudStack snapshot.
 type Snapshot struct {
 	ID   string
 	Name string
@@ -101,6 +101,7 @@ var (
 // client is the implementation of Interface.
 type client struct {
 	*cloudstack.CloudStackClient
+	projectID string // Used by some specific cloudstack api calls
 }
 
 // New creates a new cloud connector, given its configuration.
@@ -114,5 +115,5 @@ func New(config *Config) Interface {
 		klog.Background().V(2).Info("Set projectID to cloud connector", "projectID", config.ProjectID)
 	}
 
-	return &client{csClient}
+	return &client{csClient, config.ProjectID}
 }

--- a/pkg/cloud/snapshots.go
+++ b/pkg/cloud/snapshots.go
@@ -34,12 +34,8 @@ func (c *client) GetSnapshotByID(ctx context.Context, snapshotID string) (*Snaps
 	if snapshotID != "" {
 		p.SetId(snapshotID)
 	}
-	if c.projectID != "" {
-		p.SetProjectid(c.projectID)
-	}
 	logger.V(2).Info("CloudStack API call", "command", "ListSnapshots", "params", map[string]string{
-		"id":        snapshotID,
-		"projectid": c.projectID,
+		"id": snapshotID,
 	})
 	l, err := c.Snapshot.ListSnapshots(p)
 	if err != nil {
@@ -112,12 +108,8 @@ func (c *client) GetSnapshotByName(ctx context.Context, name string) (*Snapshot,
 	}
 	p := c.Snapshot.NewListSnapshotsParams()
 	p.SetName(name)
-	if c.projectID != "" {
-		p.SetProjectid(c.projectID)
-	}
 	logger.V(2).Info("CloudStack API call", "command", "ListSnapshots", "params", map[string]string{
-		"name":      name,
-		"projectid": c.projectID,
+		"name": name,
 	})
 	l, err := c.Snapshot.ListSnapshots(p)
 	if err != nil {
@@ -152,13 +144,9 @@ func (c *client) ListSnapshots(ctx context.Context, volumeID, snapshotID string)
 	if volumeID != "" {
 		p.SetVolumeid(volumeID)
 	}
-	if c.projectID != "" {
-		p.SetProjectid(c.projectID)
-	}
 	logger.V(2).Info("CloudStack API call", "command", "ListSnapshots", "params", map[string]string{
-		"id":        snapshotID,
-		"volumeid":  volumeID,
-		"projectid": c.projectID,
+		"id":       snapshotID,
+		"volumeid": volumeID,
 	})
 	l, err := c.Snapshot.ListSnapshots(p)
 	if err != nil {

--- a/pkg/cloud/snapshots.go
+++ b/pkg/cloud/snapshots.go
@@ -31,9 +31,7 @@ import (
 func (c *client) GetSnapshotByID(ctx context.Context, snapshotID string) (*Snapshot, error) {
 	logger := klog.FromContext(ctx)
 	p := c.Snapshot.NewListSnapshotsParams()
-	if snapshotID != "" {
-		p.SetId(snapshotID)
-	}
+	p.SetId(snapshotID)
 	logger.V(2).Info("CloudStack API call", "command", "ListSnapshots", "params", map[string]string{
 		"id": snapshotID,
 	})
@@ -63,9 +61,7 @@ func (c *client) GetSnapshotByID(ctx context.Context, snapshotID string) (*Snaps
 func (c *client) CreateSnapshot(ctx context.Context, volumeID, name string) (*Snapshot, error) {
 	logger := klog.FromContext(ctx)
 	p := c.Snapshot.NewCreateSnapshotParams(volumeID)
-	if name != "" {
-		p.SetName(name)
-	}
+	p.SetName(name)
 	logger.V(2).Info("CloudStack API call", "command", "CreateSnapshot", "params", map[string]string{
 		"volumeid": volumeID,
 		"name":     name,
@@ -103,9 +99,6 @@ func (c *client) DeleteSnapshot(_ context.Context, snapshotID string) error {
 
 func (c *client) GetSnapshotByName(ctx context.Context, name string) (*Snapshot, error) {
 	logger := klog.FromContext(ctx)
-	if name == "" {
-		return nil, ErrNotFound
-	}
 	p := c.Snapshot.NewListSnapshotsParams()
 	p.SetName(name)
 	logger.V(2).Info("CloudStack API call", "command", "ListSnapshots", "params", map[string]string{
@@ -138,12 +131,16 @@ func (c *client) GetSnapshotByName(ctx context.Context, name string) (*Snapshot,
 func (c *client) ListSnapshots(ctx context.Context, volumeID, snapshotID string) ([]*Snapshot, error) {
 	logger := klog.FromContext(ctx)
 	p := c.Snapshot.NewListSnapshotsParams()
+
+	// snapshotID is optional: csi.ListSnapshotsRequest
 	if snapshotID != "" {
 		p.SetId(snapshotID)
 	}
+	// volumeID is optional: csi.ListSnapshotsRequest
 	if volumeID != "" {
 		p.SetVolumeid(volumeID)
 	}
+
 	logger.V(2).Info("CloudStack API call", "command", "ListSnapshots", "params", map[string]string{
 		"id":       snapshotID,
 		"volumeid": volumeID,

--- a/pkg/cloud/snapshots.go
+++ b/pkg/cloud/snapshots.go
@@ -30,32 +30,23 @@ import (
 
 func (c *client) GetSnapshotByID(ctx context.Context, snapshotID string) (*Snapshot, error) {
 	logger := klog.FromContext(ctx)
-	p := c.Snapshot.NewListSnapshotsParams()
-	p.SetId(snapshotID)
-	logger.V(2).Info("CloudStack API call", "command", "ListSnapshots", "params", map[string]string{
+	logger.V(2).Info("CloudStack API call", "command", "GetSnapshotByID", "params", map[string]string{
 		"id": snapshotID,
 	})
-	l, err := c.Snapshot.ListSnapshots(p)
+
+	snapshot, _, err := c.Snapshot.GetSnapshotByID(snapshotID)
 	if err != nil {
 		return nil, err
 	}
-	if l.Count == 0 {
-		return nil, ErrNotFound
-	}
-	if l.Count > 1 {
-		return nil, ErrTooManyResults
-	}
-	snapshot := l.Snapshots[0]
-	s := Snapshot{
+
+	return &Snapshot{
 		ID:        snapshot.Id,
 		Name:      snapshot.Name,
 		DomainID:  snapshot.Domainid,
 		ProjectID: snapshot.Projectid,
 		ZoneID:    snapshot.Zoneid,
 		VolumeID:  snapshot.Volumeid,
-	}
-
-	return &s, nil
+	}, nil
 }
 
 func (c *client) CreateSnapshot(ctx context.Context, volumeID, name string) (*Snapshot, error) {
@@ -72,7 +63,7 @@ func (c *client) CreateSnapshot(ctx context.Context, volumeID, name string) (*Sn
 		return nil, status.Errorf(codes.Internal, "Error %v", err)
 	}
 
-	snap := Snapshot{
+	return &Snapshot{
 		ID:        snapshot.Id,
 		Name:      snapshot.Name,
 		Size:      snapshot.Virtualsize,
@@ -81,9 +72,7 @@ func (c *client) CreateSnapshot(ctx context.Context, volumeID, name string) (*Sn
 		ZoneID:    snapshot.Zoneid,
 		VolumeID:  snapshot.Volumeid,
 		CreatedAt: snapshot.Created,
-	}
-
-	return &snap, nil
+	}, nil
 }
 
 func (c *client) DeleteSnapshot(_ context.Context, snapshotID string) error {
@@ -99,23 +88,15 @@ func (c *client) DeleteSnapshot(_ context.Context, snapshotID string) error {
 
 func (c *client) GetSnapshotByName(ctx context.Context, name string) (*Snapshot, error) {
 	logger := klog.FromContext(ctx)
-	p := c.Snapshot.NewListSnapshotsParams()
-	p.SetName(name)
-	logger.V(2).Info("CloudStack API call", "command", "ListSnapshots", "params", map[string]string{
+	logger.V(2).Info("CloudStack API call", "command", "GetSnapshotByName", "params", map[string]string{
 		"name": name,
 	})
-	l, err := c.Snapshot.ListSnapshots(p)
+	snapshot, _, err := c.Snapshot.GetSnapshotByName(name)
 	if err != nil {
 		return nil, err
 	}
-	if l.Count == 0 {
-		return nil, ErrNotFound
-	}
-	if l.Count > 1 {
-		return nil, ErrTooManyResults
-	}
-	snapshot := l.Snapshots[0]
-	s := Snapshot{
+
+	return &Snapshot{
 		ID:        snapshot.Id,
 		Name:      snapshot.Name,
 		DomainID:  snapshot.Domainid,
@@ -123,15 +104,12 @@ func (c *client) GetSnapshotByName(ctx context.Context, name string) (*Snapshot,
 		ZoneID:    snapshot.Zoneid,
 		VolumeID:  snapshot.Volumeid,
 		CreatedAt: snapshot.Created,
-	}
-
-	return &s, nil
+	}, nil
 }
 
 func (c *client) ListSnapshots(ctx context.Context, volumeID, snapshotID string) ([]*Snapshot, error) {
 	logger := klog.FromContext(ctx)
 	p := c.Snapshot.NewListSnapshotsParams()
-
 	// snapshotID is optional: csi.ListSnapshotsRequest
 	if snapshotID != "" {
 		p.SetId(snapshotID)
@@ -139,6 +117,11 @@ func (c *client) ListSnapshots(ctx context.Context, volumeID, snapshotID string)
 	// volumeID is optional: csi.ListSnapshotsRequest
 	if volumeID != "" {
 		p.SetVolumeid(volumeID)
+	}
+
+	// There is no list function that uses the client default project id
+	if c.projectID != "" {
+		p.SetProjectid(c.projectID)
 	}
 
 	logger.V(2).Info("CloudStack API call", "command", "ListSnapshots", "params", map[string]string{

--- a/pkg/cloud/snapshots.go
+++ b/pkg/cloud/snapshots.go
@@ -119,7 +119,7 @@ func (c *client) ListSnapshots(ctx context.Context, volumeID, snapshotID string)
 		p.SetVolumeid(volumeID)
 	}
 
-	// There is no list function that uses the client default project id
+	// There is no list function that uses the client default project id option
 	if c.projectID != "" {
 		p.SetProjectid(c.projectID)
 	}

--- a/pkg/cloud/snapshots.go
+++ b/pkg/cloud/snapshots.go
@@ -34,8 +34,12 @@ func (c *client) GetSnapshotByID(ctx context.Context, snapshotID string) (*Snaps
 		"id": snapshotID,
 	})
 
-	snapshot, _, err := c.Snapshot.GetSnapshotByID(snapshotID)
+	snapshot, count, err := c.Snapshot.GetSnapshotByID(snapshotID)
 	if err != nil {
+		if count == 0 {
+			return nil, ErrNotFound
+		}
+
 		return nil, err
 	}
 
@@ -91,8 +95,12 @@ func (c *client) GetSnapshotByName(ctx context.Context, name string) (*Snapshot,
 	logger.V(2).Info("CloudStack API call", "command", "GetSnapshotByName", "params", map[string]string{
 		"name": name,
 	})
-	snapshot, _, err := c.Snapshot.GetSnapshotByName(name)
+	snapshot, count, err := c.Snapshot.GetSnapshotByName(name)
 	if err != nil {
+		if count == 0 {
+			return nil, ErrNotFound
+		}
+
 		return nil, err
 	}
 

--- a/pkg/cloud/vms.go
+++ b/pkg/cloud/vms.go
@@ -29,8 +29,7 @@ import (
 func (c *client) GetVMByID(ctx context.Context, vmID string) (*VM, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("CloudStack API call", "command", "ListVirtualMachines", "params", map[string]string{
-		"id":        vmID,
-		"projectID": c.projectID,
+		"id": vmID,
 	})
 
 	return c.getVMByParam(ctx, func(p *cloudstack.ListVirtualMachinesParams) {
@@ -41,8 +40,7 @@ func (c *client) GetVMByID(ctx context.Context, vmID string) (*VM, error) {
 func (c *client) getVMByName(ctx context.Context, name string) (*VM, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("CloudStack API call", "command", "ListVirtualMachines", "params", map[string]string{
-		"name":      name,
-		"projectID": c.projectID,
+		"name": name,
 	})
 
 	return c.getVMByParam(ctx, func(p *cloudstack.ListVirtualMachinesParams) {
@@ -52,10 +50,6 @@ func (c *client) getVMByName(ctx context.Context, name string) (*VM, error) {
 
 func (c *client) getVMByParam(ctx context.Context, setParams func(p *cloudstack.ListVirtualMachinesParams)) (*VM, error) {
 	p := c.VirtualMachine.NewListVirtualMachinesParams()
-
-	if c.projectID != "" {
-		p.SetProjectid(c.projectID)
-	}
 
 	// set params for virtual machine list
 	setParams(p)

--- a/pkg/cloud/vms.go
+++ b/pkg/cloud/vms.go
@@ -31,8 +31,12 @@ func (c *client) GetVMByID(ctx context.Context, vmID string) (*VM, error) {
 		"id": vmID,
 	})
 
-	vm, _, err := c.VirtualMachine.GetVirtualMachineByID(vmID)
+	vm, count, err := c.VirtualMachine.GetVirtualMachineByID(vmID)
 	if err != nil {
+		if count == 0 {
+			return nil, ErrNotFound
+		}
+
 		return nil, err
 	}
 
@@ -48,8 +52,12 @@ func (c *client) getVMByName(ctx context.Context, name string) (*VM, error) {
 		"name": name,
 	})
 
-	vm, _, err := c.VirtualMachine.GetVirtualMachineByName(name)
+	vm, count, err := c.VirtualMachine.GetVirtualMachineByName(name)
 	if err != nil {
+		if count == 0 {
+			return nil, ErrNotFound
+		}
+
 		return nil, err
 	}
 

--- a/pkg/cloud/volumes.go
+++ b/pkg/cloud/volumes.go
@@ -62,12 +62,8 @@ func (c *client) GetVolumeByID(ctx context.Context, volumeID string) (*Volume, e
 	logger := klog.FromContext(ctx)
 	p := c.Volume.NewListVolumesParams()
 	p.SetId(volumeID)
-	if c.projectID != "" {
-		p.SetProjectid(c.projectID)
-	}
 	logger.V(2).Info("CloudStack API call", "command", "ListVolumes", "params", map[string]string{
-		"id":        volumeID,
-		"projectid": c.projectID,
+		"id": volumeID,
 	})
 
 	return c.listVolumes(p)
@@ -91,15 +87,11 @@ func (c *client) CreateVolume(ctx context.Context, diskOfferingID, zoneID, name 
 	p.SetZoneid(zoneID)
 	p.SetName(name)
 	p.SetSize(sizeInGB)
-	if c.projectID != "" {
-		p.SetProjectid(c.projectID)
-	}
 	logger.V(2).Info("CloudStack API call", "command", "CreateVolume", "params", map[string]string{
 		"diskofferingid": diskOfferingID,
 		"zoneid":         zoneID,
 		"name":           name,
 		"size":           strconv.FormatInt(sizeInGB, 10),
-		"projectid":      c.projectID,
 	})
 	vol, err := c.Volume.CreateVolume(p)
 	if err != nil {
@@ -199,7 +191,6 @@ func (c *client) CreateVolumeFromSnapshot(ctx context.Context, zoneID, name, pro
 		"name":       name,
 		"size":       strconv.FormatInt(sizeInGB, 10),
 		"snapshotid": snapshotID,
-		"projectid":  projectID,
 		"zoneid":     zoneID,
 	})
 	// Execute the API call to create volume from snapshot

--- a/pkg/cloud/volumes.go
+++ b/pkg/cloud/volumes.go
@@ -31,19 +31,8 @@ import (
 	"github.com/cloudstack/cloudstack-csi-driver/pkg/util"
 )
 
-func (c *client) listVolumes(p *cloudstack.ListVolumesParams) (*Volume, error) {
-	l, err := c.Volume.ListVolumes(p)
-	if err != nil {
-		return nil, err
-	}
-	if l.Count == 0 {
-		return nil, ErrNotFound
-	}
-	if l.Count > 1 {
-		return nil, ErrTooManyResults
-	}
-	vol := l.Volumes[0]
-	v := Volume{
+func mapVolume(vol *cloudstack.Volume) *Volume {
+	return &Volume{
 		ID:               vol.Id,
 		Name:             vol.Name,
 		Size:             vol.Size,
@@ -54,30 +43,36 @@ func (c *client) listVolumes(p *cloudstack.ListVolumesParams) (*Volume, error) {
 		VirtualMachineID: vol.Virtualmachineid,
 		DeviceID:         strconv.FormatInt(vol.Deviceid, 10),
 	}
-
-	return &v, nil
 }
 
 func (c *client) GetVolumeByID(ctx context.Context, volumeID string) (*Volume, error) {
 	logger := klog.FromContext(ctx)
-	p := c.Volume.NewListVolumesParams()
-	p.SetId(volumeID)
-	logger.V(2).Info("CloudStack API call", "command", "ListVolumes", "params", map[string]string{
+	logger.V(2).Info("CloudStack API call", "command", "GetVolumeByID", "params", map[string]string{
 		"id": volumeID,
 	})
 
-	return c.listVolumes(p)
+	volume, _, err := c.Volume.GetVolumeByID(volumeID)
+	if err != nil {
+		return nil, err
+	}
+
+	return mapVolume(volume), nil
 }
 
 func (c *client) GetVolumeByName(ctx context.Context, name string) (*Volume, error) {
 	logger := klog.FromContext(ctx)
 	p := c.Volume.NewListVolumesParams()
 	p.SetName(name)
-	logger.V(2).Info("CloudStack API call", "command", "ListVolumes", "params", map[string]string{
+	logger.V(2).Info("CloudStack API call", "command", "GetVolumeByName", "params", map[string]string{
 		"name": name,
 	})
 
-	return c.listVolumes(p)
+	volume, _, err := c.Volume.GetVolumeByName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return mapVolume(volume), nil
 }
 
 func (c *client) CreateVolume(ctx context.Context, diskOfferingID, zoneID, name string, sizeInGB int64) (string, error) {
@@ -87,6 +82,10 @@ func (c *client) CreateVolume(ctx context.Context, diskOfferingID, zoneID, name 
 	p.SetZoneid(zoneID)
 	p.SetName(name)
 	p.SetSize(sizeInGB)
+	// There is no create function that uses the client default project id
+	if c.projectID != "" {
+		p.SetProjectid(c.projectID)
+	}
 	logger.V(2).Info("CloudStack API call", "command", "CreateVolume", "params", map[string]string{
 		"diskofferingid": diskOfferingID,
 		"zoneid":         zoneID,
@@ -200,7 +199,7 @@ func (c *client) CreateVolumeFromSnapshot(ctx context.Context, zoneID, name, pro
 		return nil, fmt.Errorf("failed to create volume from snapshot '%s': %w", snapshotID, err)
 	}
 
-	v := Volume{
+	return &Volume{
 		ID:               vol.Id,
 		Name:             vol.Name,
 		Size:             vol.Size,
@@ -210,7 +209,5 @@ func (c *client) CreateVolumeFromSnapshot(ctx context.Context, zoneID, name, pro
 		ZoneID:           vol.Zoneid,
 		VirtualMachineID: vol.Virtualmachineid,
 		DeviceID:         strconv.FormatInt(vol.Deviceid, 10),
-	}
-
-	return &v, nil
+	}, nil
 }

--- a/pkg/cloud/volumes.go
+++ b/pkg/cloud/volumes.go
@@ -51,8 +51,12 @@ func (c *client) GetVolumeByID(ctx context.Context, volumeID string) (*Volume, e
 		"id": volumeID,
 	})
 
-	volume, _, err := c.Volume.GetVolumeByID(volumeID)
+	volume, count, err := c.Volume.GetVolumeByID(volumeID)
 	if err != nil {
+		if count == 0 {
+			return nil, ErrNotFound
+		}
+
 		return nil, err
 	}
 
@@ -67,8 +71,12 @@ func (c *client) GetVolumeByName(ctx context.Context, name string) (*Volume, err
 		"name": name,
 	})
 
-	volume, _, err := c.Volume.GetVolumeByName(name)
+	volume, count, err := c.Volume.GetVolumeByName(name)
 	if err != nil {
+		if count == 0 {
+			return nil, ErrNotFound
+		}
+
 		return nil, err
 	}
 

--- a/pkg/cloud/volumes.go
+++ b/pkg/cloud/volumes.go
@@ -82,7 +82,7 @@ func (c *client) CreateVolume(ctx context.Context, diskOfferingID, zoneID, name 
 	p.SetZoneid(zoneID)
 	p.SetName(name)
 	p.SetSize(sizeInGB)
-	// There is no create function that uses the client default project id
+	// There is no create function that uses the client default project id option
 	if c.projectID != "" {
 		p.SetProjectid(c.projectID)
 	}


### PR DESCRIPTION
*Description of changes:*
The client only uses the project ID in the function `GetVMByID` and not in the function `getVMByName`. This causes the CSI where the instance ID is not found in the metadata and the VM is in a project to fail. Eventually they fall back into a crash loop back off and the CSI is not usable.

It refactors all functions of the `cloud` package to use the default project_id option. This reduces code duplication by using cloudstack client `methods` that support the default options. This refactoring is based on the following fix: It fixes the function `getVMByName` by using the method `GetVirtualMachineByName` instead of `ListVirtualMachines`.

These changes ensure that the project id is automatically included and makes the code more mature.

*Testing performed:*
I installed k8s into Cloudstack inside of a project and without. The setup of the CSI worked when running in the root project but not in sub projects with the current version 3.0.0. I am using my PR version currently in a cluster on a Cloudstack instance within a project and with that it is working just fine.

Please create a bugfix release when the PR is approved and merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
